### PR TITLE
fix: improve scrolling behavior in console and main screen

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -259,10 +259,20 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.Action == tea.MouseActionPress {
 			switch msg.Button {
 			case tea.MouseButtonWheelUp:
-				m.tabbedWindow.ScrollUp()
+				// If no instance selected, scroll the instance list
+				if m.list.GetSelectedInstance() == nil {
+					m.list.Up()
+				} else {
+					m.tabbedWindow.ScrollUp()
+				}
 				return m, m.instanceChanged()
 			case tea.MouseButtonWheelDown:
-				m.tabbedWindow.ScrollDown()
+				// If no instance selected, scroll the instance list
+				if m.list.GetSelectedInstance() == nil {
+					m.list.Down()
+				} else {
+					m.tabbedWindow.ScrollDown()
+				}
 				return m, m.instanceChanged()
 			}
 		}
@@ -726,16 +736,36 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 		m.list.Down()
 		return m, m.instanceChanged()
 	case keys.KeyShiftUp:
-		m.tabbedWindow.ScrollUp()
+		// If no instance selected, scroll the instance list
+		if m.list.GetSelectedInstance() == nil {
+			m.list.Up()
+		} else {
+			m.tabbedWindow.ScrollUp()
+		}
 		return m, m.instanceChanged()
 	case keys.KeyShiftDown:
-		m.tabbedWindow.ScrollDown()
+		// If no instance selected, scroll the instance list
+		if m.list.GetSelectedInstance() == nil {
+			m.list.Down()
+		} else {
+			m.tabbedWindow.ScrollDown()
+		}
 		return m, m.instanceChanged()
 	case keys.KeyCtrlShiftUp:
-		m.tabbedWindow.FastScrollUp()
+		// If no instance selected, scroll the instance list (fast)
+		if m.list.GetSelectedInstance() == nil {
+			m.list.Up()
+		} else {
+			m.tabbedWindow.FastScrollUp()
+		}
 		return m, m.instanceChanged()
 	case keys.KeyCtrlShiftDown:
-		m.tabbedWindow.FastScrollDown()
+		// If no instance selected, scroll the instance list (fast)
+		if m.list.GetSelectedInstance() == nil {
+			m.list.Down()
+		} else {
+			m.tabbedWindow.FastScrollDown()
+		}
 		return m, m.instanceChanged()
 	case keys.KeyTab:
 		m.tabbedWindow.Toggle()
@@ -892,8 +922,10 @@ func (m *home) instanceChanged() tea.Cmd {
 	}
 
 	// Save instances after changes (including restart/MCP updates)
-	if err := m.storage.SaveInstances(m.list.GetInstances()); err != nil {
-		return m.handleError(err)
+	if m.storage != nil {
+		if err := m.storage.SaveInstances(m.list.GetInstances()); err != nil {
+			return m.handleError(err)
+		}
 	}
 
 	return nil

--- a/ui/console.go
+++ b/ui/console.go
@@ -173,6 +173,10 @@ func (c *ConsolePane) UpdateContent(instance *session.Instance) error {
 
 // ScrollUp scrolls the viewport up
 func (c *ConsolePane) ScrollUp() {
+	// If already at top, don't scroll - let tmux handle history navigation
+	if c.viewport.AtTop() {
+		return
+	}
 	c.viewport.LineUp(1)
 	// Update the map with the modified viewport
 	c.syncViewportToMap()
@@ -187,6 +191,10 @@ func (c *ConsolePane) ScrollDown() {
 
 // FastScrollUp scrolls the viewport up by 10 lines
 func (c *ConsolePane) FastScrollUp() {
+	// If already at top, don't scroll - let tmux handle history navigation
+	if c.viewport.AtTop() {
+		return
+	}
 	c.viewport.LineUp(10)
 	// Update the map with the modified viewport
 	c.syncViewportToMap()


### PR DESCRIPTION
## Summary
• Fix console scroll to not interfere with tmux history when at top
• Add scroll support for main screen when no instance is selected
• Enhance mouse scroll to work consistently across the application

## Test plan
- [x] Console tab: Shift+Arrow no longer interferes with tmux history
- [x] Main screen: Mouse and keyboard scroll work when no instance selected
- [x] All existing scroll functionality preserved
- [x] All tests passing

🤖 Generated with [Claude Code](https://claude.ai/code)